### PR TITLE
chore: adding CODEOWNERS, repo.yml file

### DIFF
--- a/.devrev/repo.yml
+++ b/.devrev/repo.yml
@@ -1,0 +1,1 @@
+deployable: false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code owners
+@SathishKumarHS


### PR DESCRIPTION
This PR adds a `.devrev/repo.yml` and `.github/CODEOWNERS` file